### PR TITLE
Proxy git args to scripts with custom runners

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -216,6 +216,7 @@ func executeScript(hooksGroup, source string, executable os.FileInfo, wg *sync.W
 	if haveRunner(hooksGroup, scriptsConfigKey, executableName) {
 		runnerArg := strings.Split(getRunner(hooksGroup, scriptsConfigKey, executableName), " ")
 		runnerArg = append(runnerArg, pathToExecutable)
+		runnerArg = append(runnerArg, gitArgs[:]...)
 
 		command = exec.Command(runnerArg[0], runnerArg[1:]...)
 	}


### PR DESCRIPTION
Given the following example:

```yml
prepare-commit-msg:
  scripts:
    "jira_link.rb":
      runner: ruby
```

Git args are not passed to the script.

This PR fixes this.